### PR TITLE
refactor: remove multiple viewport & max width...

### DIFF
--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -36,11 +36,10 @@
     <!-- Default non-defined size, also used for Android 2.1+ devices -->
     <link rel="apple-touch-icon-precomposed" href="/api/payment/images/apple-touch-icon-60x60.png?0.15.1">
 
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta property="og:image" content="/api/payment/images/opengraph-image.png?0.15.1">
 
     <!-- Viewport mobile tag for sensible mobile support -->
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!--STYLES-->
     <link rel="stylesheet" href="/api/payment/styles/application.css">


### PR DESCRIPTION
# Description
This fixes this a11y issue picked up by cypress-axe https://dequeuniversity.com/rules/axe/4.2/meta-viewport.

The issue isn't exactly addressed the way it is in the link shared above but I think removing the duplication and `maximum-scale` did something to fix it.