### PR TITLE
Fix service DB config settings

### DIFF
--- a/config/payment.js
+++ b/config/payment.js
@@ -39,7 +39,7 @@ const cookieDomain = {
 
 const db = {
   ...defaultDBConfig,
-  ...(process.env.EDMS_BEARER_TOKEN ? JSON.parse(process.env.EDMS_BEARER_TOKEN) : {}),
+  ...(process.env.DATABASE ? JSON.parse(process.env.DATABASE) : {}),
 }
 
 const live_variables = {

--- a/models/index.js
+++ b/models/index.js
@@ -1,6 +1,5 @@
 import { DataTypes, Sequelize } from 'sequelize'
 import { config as environmentConfig } from '../config/common.js'
-import { logger } from '../config/logs.js'
 import { AdditionalPaymentDetails as AdditionalPaymentDetailsModel } from './AdditionalPaymentDetails.js'
 import { Application as ApplicationModel } from './Application.js'
 import { ApplicationPaymentDetails as ApplicationPaymentDetailsModel } from './ApplicationPaymentDetails.js'
@@ -24,11 +23,6 @@ const opts = {
   },
 }
 
-logger.info(
-  `initialising Sequelize with database config: ${environmentConfig.configGovukPay.database}`,
-  'and options: ',
-  opts,
-)
 // initialise Sequelize
 export const sequelize = new Sequelize(environmentConfig.configGovukPay.database, opts)
 


### PR DESCRIPTION
When the service was being built we had set the wrong DB connection info in the environment variable. This was introduced in error here https://github.com/UKForeignOffice/loi-payment-service/pull/157/changes#diff-b4091c79bc8b3f5a9941c96305f5f4e464b5e6c15a3c8084a2f485a2428e452aR42 using a non-existent env variable relating to a token rather than the correct DATABASE env variable object.